### PR TITLE
make urls.py django 2.x compatible

### DIFF
--- a/genericdropdown/urls.py
+++ b/genericdropdown/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import url
+from .views import updateCombo
 
 urlpatterns = [
-    url(r'^updatecombo/(?P<id>\d+)?$', 'genericdropdown.views.updateCombo', name='updatecombo'),
+    url(r'^updatecombo/(?P<id>\d+)?$', updateCombo, name='updatecombo'),
 ]


### PR DESCRIPTION
1) I accidentally removed the `url` function =(
2) Importantly, you can't have strings as view in django 1.10+